### PR TITLE
Add CadQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [GetFEM](https://getfem.org) - Framework for solving systems of coupled nonlinear PDEs with the finite element method. ![C++](https://img.shields.io/badge/c++-%2300599C.svg?logo=c%2B%2B&logoColor=white) ![Python](https://img.shields.io/badge/python-3670A0?logo=python&logoColor=ffdd54) ![Octave](https://img.shields.io/badge/OCTAVE-darkblue?logo=octave&logoColor=fcd683)
 - [scikit-fem](https://scikit-fem.readthedocs.io/en/latest/) - Simple finite element assemblers ![Python](https://img.shields.io/badge/python-3670A0?logo=python&logoColor=ffdd54)
 - [PyVista](https://docs.pyvista.org/version/stable/) - 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK) ![Python](https://img.shields.io/badge/python-3670A0?logo=python&logoColor=ffdd54)
+- [CadQuery](https://cadquery.readthedocs.io/en/latest/) - A python parametric CAD scripting framework based on OCCT ![Python](https://img.shields.io/badge/python-3670A0?logo=python&logoColor=ffdd54)
 
 ## Encyclopedia
 


### PR DESCRIPTION
## What is this mechanical FEA tool?

CadQuery is an intuitive, easy-to-use Python library for building parametric 3D CAD models.  It has several goals:

* Build models with scripts that are as close as possible to how you'd describe the object to a human,
  using a standard, already established programming language

* Create parametric models that can be very easily customized by end users

* Output high quality CAD formats like STEP, AMF and 3MF in addition to traditional STL

* Provide a non-proprietary, plain text model format that can be edited and executed with only a web browser

## What's the difference between this mechanical FEA tool and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an _Approve_ review to it.

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

<!-- END doctoc generated TOC please keep comment here to allow auto update -->
