### PR TITLE
Add scikit-topt to PDE Solver section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [pyelmer](https://github.com/nemocrys/pyelmer) – A python interface to Elmer.
 - [PyMAPDL](https://github.com/ansys/pymapdl) – The PyMAPDL project supports Pythonic access to MAPDL.
 - [scikit-fem](https://scikit-fem.readthedocs.io/en/latest/) – Simple finite element assemblers
-- [scikit-topt](https://github.com/kevin-tofu/scikit-topt) – Scikit Topology Optimization with Scipy
+- [scikit-topt](https://github.com/kevin-tofu/scikit-topt) – Scikit Topology Optimization with SciPy
 - [Symfem](https://symfem.readthedocs.io/en/latest/) – A symbolic finite element definition library
 - [Xara](https://github.com/peer-open-source/xara) – A batteries-included Python package for fast nonlinear finite element analysis (solid mechanics) ![Python](media/icon/python.png)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [pyelmer](https://github.com/nemocrys/pyelmer) – A python interface to Elmer.
 - [PyMAPDL](https://github.com/ansys/pymapdl) – The PyMAPDL project supports Pythonic access to MAPDL.
 - [scikit-fem](https://scikit-fem.readthedocs.io/en/latest/) – Simple finite element assemblers
+- [scikit-topt](https://github.com/kevin-tofu/scikit-topt) – A lightweight, flexible Python library for topology optimization built on top of Scikit Libraries
 - [Symfem](https://symfem.readthedocs.io/en/latest/) – A symbolic finite element definition library
 - [Xara](https://github.com/peer-open-source/xara) – A batteries-included Python package for fast nonlinear finite element analysis (solid mechanics) ![Python](media/icon/python.png)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [pyelmer](https://github.com/nemocrys/pyelmer) – A python interface to Elmer.
 - [PyMAPDL](https://github.com/ansys/pymapdl) – The PyMAPDL project supports Pythonic access to MAPDL.
 - [scikit-fem](https://scikit-fem.readthedocs.io/en/latest/) – Simple finite element assemblers
-- [scikit-topt](https://github.com/kevin-tofu/scikit-topt) – A lightweight, flexible Python library for topology optimization built on top of Scikit Libraries
+- [scikit-topt](https://github.com/kevin-tofu/scikit-topt) – Scikit Topology Optimization with Scipy
 - [Symfem](https://symfem.readthedocs.io/en/latest/) – A symbolic finite element definition library
 - [Xara](https://github.com/peer-open-source/xara) – A batteries-included Python package for fast nonlinear finite element analysis (solid mechanics) ![Python](media/icon/python.png)
 


### PR DESCRIPTION
## Summary
- Added scikit-topt Python library to the PDE Solver section
- scikit-topt is a lightweight topology optimization library built on Scikit Libraries
- Supports multiple optimization algorithms (OC, Modified OC, Lagrangian methods)
- Provides FEA capabilities on unstructured meshes

## Test plan
- [x] Verify the link is accessible and correct
- [x] Confirm alphabetical ordering in the PDE Solver section
- [x] Check that description is concise and informative

🤖 Generated with [Claude Code](https://claude.ai/code)